### PR TITLE
Fix broken link in biquad::coefficients.

### DIFF
--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -9,7 +9,7 @@
 //! ```
 //!
 //! The second orders filter are based on the
-//! [Audio EQ Cookbook](http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt), while the first order
+//! [Audio EQ Cookbook](https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html), while the first order
 //! low pass filter is based on the following
 //! [Wikipedia article](https://en.wikipedia.org/wiki/Low-pass_filter#Discrete-time_realization).
 //!


### PR DESCRIPTION
The previous link (http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt)
appears to be dead. I've replaced it with this link: https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html
which seems to have the same content.

This fixes #6.