### PR TITLE
Add the rest of the filters described in the Audio EQ Cookbook.

### DIFF
--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -59,6 +59,7 @@ pub enum Type {
     BandPass,
     Notch,
     LowShelf(DBGain),
+    HighShelf(DBGain),
 }
 
 /// Holder of the biquad coefficients, utilizes normalized form
@@ -215,6 +216,27 @@ impl Coefficients<f32> {
                     b2: b2 / a0,
                 })
             }
+            Type::HighShelf(db_gain) => {
+                let a = 10.0f32.powf(db_gain / 40.0);
+                let omega_s = omega.sin();
+                let omega_c = omega.cos();
+                let alpha = omega_s / (2.0 * q_value);
+
+                let b0 = a * ((a + 1.0) + (a - 1.0) * omega_c + 2.0 * alpha * a.sqrt());
+                let b1 = -2.0 * a * ((a - 1.0) + (a + 1.0) * omega_c);
+                let b2 = a * ((a + 1.0) + (a - 1.0) * omega_c - 2.0 * alpha * a.sqrt());
+                let a0 = (a + 1.0) - (a - 1.0) * omega_c + 2.0 * alpha * a.sqrt();
+                let a1 = 2.0 * ((a - 1.0) - (a + 1.0) * omega_c);
+                let a2 = (a + 1.0) - (a - 1.0) * omega_c - 2.0 * alpha * a.sqrt();
+
+                Ok(Coefficients {
+                    a1: a1 / a0,
+                    a2: a2 / a0,
+                    b0: b0 / a0,
+                    b1: b1 / a0,
+                    b2: b2 / a0,
+                })
+            }
         }
     }
 }
@@ -343,6 +365,7 @@ impl Coefficients<f64> {
                 })
             }
             Type::LowShelf(_) => unimplemented!("Not yet implemeneted!"),
+            Type::HighShelf(_) => unimplemented!("Not yet implemeneted!"),
         }
     }
 }

--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -60,6 +60,7 @@ pub enum Type {
     Notch,
     LowShelf(DBGain),
     HighShelf(DBGain),
+    PeakingEQ(DBGain),
 }
 
 /// Holder of the biquad coefficients, utilizes normalized form
@@ -237,6 +238,27 @@ impl Coefficients<f32> {
                     b2: b2 / a0,
                 })
             }
+            Type::PeakingEQ(db_gain) => {
+                let a = 10.0f32.powf(db_gain / 40.0);
+                let omega_s = omega.sin();
+                let omega_c = omega.cos();
+                let alpha = omega_s / (2.0 * q_value);
+
+                let b0 = 1.0 + alpha * a;
+                let b1 = -2.0 * omega_c;
+                let b2 = 1.0 - alpha * a;
+                let a0 = 1.0 + alpha / a;
+                let a1 = -2.0 * omega_c;
+                let a2 = 1.0 - alpha * a;
+
+                Ok(Coefficients {
+                    a1: a1 / a0,
+                    a2: a2 / a0,
+                    b0: b0 / a0,
+                    b1: b1 / a0,
+                    b2: b2 / a0,
+                })
+            }
         }
     }
 }
@@ -366,6 +388,7 @@ impl Coefficients<f64> {
             }
             Type::LowShelf(_) => unimplemented!("Not yet implemeneted!"),
             Type::HighShelf(_) => unimplemented!("Not yet implemeneted!"),
+            Type::PeakingEQ(_) => unimplemented!("Not yet implemeneted!"),
         }
     }
 }

--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -267,7 +267,7 @@ impl Coefficients<f32> {
                 let b2 = 1.0 - alpha * a;
                 let a0 = 1.0 + alpha / a;
                 let a1 = -2.0 * omega_c;
-                let a2 = 1.0 - alpha * a;
+                let a2 = 1.0 - alpha / a;
 
                 Ok(Coefficients {
                     a1: a1 / a0,

--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -58,6 +58,7 @@ pub enum Type {
     HighPass,
     BandPass,
     Notch,
+    AllPass,
     LowShelf(DBGain),
     HighShelf(DBGain),
     PeakingEQ(DBGain),
@@ -193,10 +194,27 @@ impl Coefficients<f32> {
                     b2: b2 / a0,
                 })
             }
-            Type::LowShelf(db_gain) => {
-                // These coefficient values are taken from the following link:
-                // https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html
+            Type::AllPass => {
+                let omega_s = omega.sin();
+                let omega_c = omega.cos();
+                let alpha = omega_s / (2.0 * q_value);
 
+                let b0 = 1.0 - alpha;
+                let b1 = -2.0 * omega_c;
+                let b2 = 1.0 + alpha;
+                let a0 = 1.0 + alpha;
+                let a1 = -2.0 * omega_c;
+                let a2 = 1.0 - alpha;
+
+                Ok(Coefficients {
+                    a1: a1 / a0,
+                    a2: a2 / a0,
+                    b0: b0 / a0,
+                    b1: b1 / a0,
+                    b2: b2 / a0,
+                })
+            }
+            Type::LowShelf(db_gain) => {
                 let a = 10.0f32.powf(db_gain / 40.0);
                 let omega_s = omega.sin();
                 let omega_c = omega.cos();
@@ -386,6 +404,7 @@ impl Coefficients<f64> {
                     b2: b2 * div,
                 })
             }
+            Type::AllPass => unimplemented!("Not yet implemented!"),
             Type::LowShelf(_) => unimplemented!("Not yet implemeneted!"),
             Type::HighShelf(_) => unimplemented!("Not yet implemeneted!"),
             Type::PeakingEQ(_) => unimplemented!("Not yet implemeneted!"),


### PR DESCRIPTION
This fixes #8.

A quick note: I implemented the gain parameter for the low shelf/high shelf/peaking EQ filters by adding it as a field to the `Type` enum, but I'm wondering if there's a better way to do this, since it makes the `Type` enum somewhat larger.