### PR TITLE
Add reset_state() and replace_coefficients() methods to the Biquad trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Reset state method added
+* Method to replace the coefficients and return the old coefficients instead of dropping them added
+
 ### Changes
 
 ## [v0.4.0] - 2020-04-10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,13 @@ pub trait Biquad<T> {
 
     /// Updating of coefficients
     fn update_coefficients(&mut self, new_coefficients: Coefficients<T>);
+
+    /// Updating coefficients and returning the old ones. This is useful to avoid deallocating on the audio thread, since 
+    /// the `Coefficients` can then be sent to another thread for deallocation.
+    fn replace_coefficients(&mut self, new_coefficients: Coefficients<T>) -> Coefficients<T>;
+
+    /// Set the internal state of the biquad to 0 without allocation.
+    fn reset_state(&mut self);
 }
 
 /// Possible errors
@@ -123,6 +130,17 @@ impl Biquad<f32> for DirectForm1<f32> {
     fn update_coefficients(&mut self, new_coefficients: Coefficients<f32>) {
         self.coeffs = new_coefficients;
     }
+
+    fn replace_coefficients(&mut self, new_coefficients: Coefficients<f32>) -> Coefficients<f32> {
+        core::mem::replace(&mut self.coeffs, new_coefficients)
+    }
+
+    fn reset_state(&mut self) {
+        self.x1 = 0.;
+        self.x2 = 0.;
+        self.y1 = 0.;
+        self.y2 = 0.;
+    }
 }
 
 impl DirectForm1<f64> {
@@ -155,6 +173,17 @@ impl Biquad<f64> for DirectForm1<f64> {
     fn update_coefficients(&mut self, new_coefficients: Coefficients<f64>) {
         self.coeffs = new_coefficients;
     }
+
+    fn replace_coefficients(&mut self, new_coefficients: Coefficients<f64>) -> Coefficients<f64> {
+        core::mem::replace(&mut self.coeffs, new_coefficients)
+    }
+
+    fn reset_state(&mut self) {
+        self.x1 = 0.;
+        self.x2 = 0.;
+        self.y1 = 0.;
+        self.y2 = 0.;
+    }
 }
 
 impl DirectForm2Transposed<f32> {
@@ -179,6 +208,15 @@ impl Biquad<f32> for DirectForm2Transposed<f32> {
 
     fn update_coefficients(&mut self, new_coefficients: Coefficients<f32>) {
         self.coeffs = new_coefficients;
+    }
+
+    fn replace_coefficients(&mut self, new_coefficients: Coefficients<f32>) -> Coefficients<f32> {
+        core::mem::replace(&mut self.coeffs, new_coefficients)
+    }
+
+    fn reset_state(&mut self) {
+        self.s1 = 0.;
+        self.s2 = 0.;
     }
 }
 
@@ -205,7 +243,17 @@ impl Biquad<f64> for DirectForm2Transposed<f64> {
     fn update_coefficients(&mut self, new_coefficients: Coefficients<f64>) {
         self.coeffs = new_coefficients;
     }
+
+    fn replace_coefficients(&mut self, new_coefficients: Coefficients<f64>) -> Coefficients<f64> {
+        core::mem::replace(&mut self.coeffs, new_coefficients)
+    }
+
+    fn reset_state(&mut self) {
+        self.s1 = 0.;
+        self.s2 = 0.;
+    }
 }
+
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Thanks for making this crate!

I added two simple nice-to-have features:
* Resetting the state variables of a filter to 0.0 (without creating a whole new filter), can be useful for retriggering synths reliably etc.
* Replacing the old coefficients and returning them instead of dropping them. This is useful if you're (like me) updating the coefficients in a real-time context and don't want to risk any deallocation on the audio thread.