### PR TITLE
add corrected first order low pass filter coefficients

### DIFF
--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -53,6 +53,7 @@ pub const Q_BUTTERWORTH_F64: f64 = core::f64::consts::FRAC_1_SQRT_2;
 /// field, and represents the gain, in decibels, that the filter provides.
 #[derive(Clone, Copy, Debug)]
 pub enum Type<DBGain> {
+    SinglePoleLowPassApprox,
     SinglePoleLowPass,
     LowPass,
     HighPass,
@@ -98,7 +99,7 @@ impl Coefficients<f32> {
         let omega = 2.0 * core::f32::consts::PI * f0.hz() / fs.hz();
 
         match filter {
-            Type::SinglePoleLowPass => {
+            Type::SinglePoleLowPassApprox => {
                 let alpha = omega / (omega + 1.0);
 
                 Ok(Coefficients {
@@ -106,6 +107,18 @@ impl Coefficients<f32> {
                     a2: 0.0,
                     b0: alpha,
                     b1: 0.0,
+                    b2: 0.0,
+                })
+            }
+            Type::SinglePoleLowPass => {
+                let omega_t = (omega / 2.0).tan();
+                let a0 = 1.0 + omega_t;
+
+                Ok(Coefficients {
+                    a1: (omega_t - 1.0) / a0,
+                    a2: 0.0,
+                    b0: omega_t / a0,
+                    b1: omega_t / a0,
                     b2: 0.0,
                 })
             }
@@ -302,7 +315,7 @@ impl Coefficients<f64> {
         let omega = 2.0 * core::f64::consts::PI * f0.hz() / fs.hz();
 
         match filter {
-            Type::SinglePoleLowPass => {
+            Type::SinglePoleLowPassApprox => {
                 let alpha = omega / (omega + 1.0);
 
                 Ok(Coefficients {
@@ -310,6 +323,18 @@ impl Coefficients<f64> {
                     a2: 0.0,
                     b0: alpha,
                     b1: 0.0,
+                    b2: 0.0,
+                })
+            }
+            Type::SinglePoleLowPass => {
+                let omega_t = (omega / 2.0).tan();
+                let a0 = 1.0 + omega_t;
+
+                Ok(Coefficients {
+                    a1: (omega_t - 1.0) / a0,
+                    a2: 0.0,
+                    b0: omega_t / a0,
+                    b1: omega_t / a0,
                     b2: 0.0,
                 })
             }


### PR DESCRIPTION
Hi Emil, Thank you for providing this crate! I am using it for scientific computing and it is very useful. Unfortunately, the existing single pole low pass filter is an approximation. The wikipedia page that its based on makes an erroneous assumption for the alpha calculation which doesn't achieve the correct cut off frequency. You can read more about it in [this stack overflow post](https://dsp.stackexchange.com/a/40465).

I have updated the coefficients to match a digital first order Butterworth filter according to [some literature](https://www.nxp.com/docs/en/application-note/AN4265.pdf), and I have confirmed that the coefficients match those from `SciPy.signal`. 

As a demonstration, I filtered a random signal in a few different ways and plotted their frequency responses (Fs = 1Hz, Fc = 0.1Hz). The corrected first order filter (and the existing second order filter) have a response of 1/sqrt(2) exactly at the cut off frequency, whereas the current first order filter (orange line) does not.

I wasn't sure the best way to add the filter. I renamed the current single pole filter to `SinglePoleLowPassApprox`, but this would break backward compatibility. So let me know what you think.

Cheers,

Jaime
![freq_response](https://user-images.githubusercontent.com/33415790/149405642-c957657f-095a-4486-94ba-9c07305ed653.png)

