### PR TITLE
Separate the generic parameter into one for input/output/state and one for coefficients

### DIFF
--- a/src/coefficients.rs
+++ b/src/coefficients.rs
@@ -66,18 +66,18 @@ pub enum Type<DBGain> {
 
 /// Holder of the biquad coefficients, utilizes normalized form
 #[derive(Clone, Copy, Debug)]
-pub struct Coefficients<T: Float> {
+pub struct Coefficients<C> {
     // Denominator coefficients
-    pub a1: T,
-    pub a2: T,
+    pub a1: C,
+    pub a2: C,
 
     // Nominator coefficients
-    pub b0: T,
-    pub b1: T,
-    pub b2: T,
+    pub b0: C,
+    pub b1: C,
+    pub b2: C,
 }
 
-impl<T: Float> Coefficients<T> {
+impl<C> Coefficients<C> where C: Float {
     /// Creates coefficients based on the biquad filter type, normalized cutoff frequency, and Q
     /// value. Note that the cutoff frequency must be smaller than 1 and that Q may not be negative,
     ///  this will result in an `Err()`.
@@ -85,20 +85,20 @@ impl<T: Float> Coefficients<T> {
     /// * `normalized_f0` - Cut frequency devided by two times sampling frequency (0<F_cut<1 respects the shanon condition)
     /// * `q_value` - Text about bar.
     pub fn from_normalized_params(
-        filter_type: Type<T>,
-        normalized_f0: T,
-        q_value: T,
-    ) -> Result<Coefficients<T>, Errors> {
+        filter_type: Type<C>,
+        normalized_f0: C,
+        q_value: C,
+    ) -> Result<Coefficients<C>, Errors> {
         #[allow(non_snake_case)]
-        let TWO: T = T::from(2).unwrap();
+        let TWO: C = C::from(2).unwrap();
         #[allow(non_snake_case)]
-        let PI: T = T::from(core::f64::consts::PI).unwrap();
+        let PI: C = C::from(core::f64::consts::PI).unwrap();
         #[allow(non_snake_case)]
-        let FORTY: T = T::from(40).unwrap();
-        if normalized_f0 >= T::one() || normalized_f0 < T::zero() {
+        let FORTY: C = C::from(40).unwrap();
+        if normalized_f0 >= C::one() || normalized_f0 < C::zero() {
             return Err(Errors::OutsideNyquist);
         }
-        if q_value <= T::zero() {
+        if q_value <= C::zero() {
             return Err(Errors::NegativeQ);
         }
         let omega = PI * normalized_f0;
@@ -108,7 +108,7 @@ impl<T: Float> Coefficients<T> {
         // assumed to be of low computational complexity.
         let (omega_s, omega_c, alpha) = match filter_type {
             Type::SinglePoleLowPassApprox | Type::SinglePoleLowPass => {
-                (T::nan(), T::nan(), T::nan())
+                (C::nan(), C::nan(), C::nan())
             }
             _ => {
                 let omega_s = omega.sin();
@@ -117,37 +117,37 @@ impl<T: Float> Coefficients<T> {
         };
         match filter_type {
             Type::SinglePoleLowPassApprox => {
-                let alpha = omega / (omega + T::one());
+                let alpha = omega / (omega + C::one());
 
                 Ok(Coefficients {
-                    a1: alpha - T::one(),
-                    a2: T::zero(),
+                    a1: alpha - C::one(),
+                    a2: C::zero(),
                     b0: alpha,
-                    b1: T::zero(),
-                    b2: T::zero(),
+                    b1: C::zero(),
+                    b2: C::zero(),
                 })
             }
             Type::SinglePoleLowPass => {
                 let omega_t = (omega / TWO).tan();
-                let a0 = T::one() + omega_t;
+                let a0 = C::one() + omega_t;
 
                 Ok(Coefficients {
-                    a1: (omega_t - T::one()) / a0,
-                    a2: T::zero(),
+                    a1: (omega_t - C::one()) / a0,
+                    a2: C::zero(),
                     b0: omega_t / a0,
                     b1: omega_t / a0,
-                    b2: T::zero(),
+                    b2: C::zero(),
                 })
             }
             Type::LowPass => {
-                let b0 = (T::one() - omega_c) / TWO;
-                let b1 = T::one() - omega_c;
-                let b2 = (T::one() - omega_c) / TWO;
-                let a0 = T::one() + alpha;
+                let b0 = (C::one() - omega_c) / TWO;
+                let b1 = C::one() - omega_c;
+                let b2 = (C::one() - omega_c) / TWO;
+                let a0 = C::one() + alpha;
                 let a1 = -TWO * omega_c;
-                let a2 = T::one() - alpha;
+                let a2 = C::one() - alpha;
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -158,14 +158,14 @@ impl<T: Float> Coefficients<T> {
                 })
             }
             Type::HighPass => {
-                let b0 = (T::one() + omega_c) / TWO;
-                let b1 = -(T::one() + omega_c);
-                let b2 = (T::one() + omega_c) / TWO;
-                let a0 = T::one() + alpha;
+                let b0 = (C::one() + omega_c) / TWO;
+                let b1 = -(C::one() + omega_c);
+                let b2 = (C::one() + omega_c) / TWO;
+                let a0 = C::one() + alpha;
                 let a1 = -TWO * omega_c;
-                let a2 = T::one() - alpha;
+                let a2 = C::one() - alpha;
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -177,13 +177,13 @@ impl<T: Float> Coefficients<T> {
             }
             Type::BandPass => {
                 let b0 = omega_s / TWO;
-                let b1 = T::zero();
+                let b1 = C::zero();
                 let b2 = -(omega_s / TWO);
-                let a0 = T::one() + alpha;
+                let a0 = C::one() + alpha;
                 let a1 = -TWO * omega_c;
-                let a2 = T::one() - alpha;
+                let a2 = C::one() - alpha;
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -194,14 +194,14 @@ impl<T: Float> Coefficients<T> {
                 })
             }
             Type::Notch => {
-                let b0 = T::one();
+                let b0 = C::one();
                 let b1 = -TWO * omega_c;
-                let b2 = T::one();
-                let a0 = T::one() + alpha;
+                let b2 = C::one();
+                let a0 = C::one() + alpha;
                 let a1 = -TWO * omega_c;
-                let a2 = T::one() - alpha;
+                let a2 = C::one() - alpha;
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -212,14 +212,14 @@ impl<T: Float> Coefficients<T> {
                 })
             }
             Type::AllPass => {
-                let b0 = T::one() - alpha;
+                let b0 = C::one() - alpha;
                 let b1 = -TWO * omega_c;
-                let b2 = T::one() + alpha;
-                let a0 = T::one() + alpha;
+                let b2 = C::one() + alpha;
+                let a0 = C::one() + alpha;
                 let a1 = -TWO * omega_c;
-                let a2 = T::one() - alpha;
+                let a2 = C::one() - alpha;
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -230,15 +230,15 @@ impl<T: Float> Coefficients<T> {
                 })
             }
             Type::LowShelf(db_gain) => {
-                let a = T::from(T::from(10).unwrap().powf(db_gain / FORTY)).unwrap();
-                let b0 = a * ((a + T::one()) - (a - T::one()) * omega_c + TWO * alpha * a.sqrt());
-                let b1 = TWO * a * ((a - T::one()) - (a + T::one()) * omega_c);
-                let b2 = a * ((a + T::one()) - (a - T::one()) * omega_c - TWO * alpha * a.sqrt());
-                let a0 = (a + T::one()) + (a - T::one()) * omega_c + TWO * alpha * a.sqrt();
-                let a1 = -TWO * ((a - T::one()) + (a + T::one()) * omega_c);
-                let a2 = (a + T::one()) + (a - T::one()) * omega_c - TWO * alpha * a.sqrt();
+                let a = C::from(C::from(10).unwrap().powf(db_gain / FORTY)).unwrap();
+                let b0 = a * ((a + C::one()) - (a - C::one()) * omega_c + TWO * alpha * a.sqrt());
+                let b1 = TWO * a * ((a - C::one()) - (a + C::one()) * omega_c);
+                let b2 = a * ((a + C::one()) - (a - C::one()) * omega_c - TWO * alpha * a.sqrt());
+                let a0 = (a + C::one()) + (a - C::one()) * omega_c + TWO * alpha * a.sqrt();
+                let a1 = -TWO * ((a - C::one()) + (a + C::one()) * omega_c);
+                let a2 = (a + C::one()) + (a - C::one()) * omega_c - TWO * alpha * a.sqrt();
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -249,16 +249,16 @@ impl<T: Float> Coefficients<T> {
                 })
             }
             Type::HighShelf(db_gain) => {
-                let a = T::from(T::from(10).unwrap().powf(db_gain / FORTY)).unwrap();
+                let a = C::from(C::from(10).unwrap().powf(db_gain / FORTY)).unwrap();
 
-                let b0 = a * ((a + T::one()) + (a - T::one()) * omega_c + TWO * alpha * a.sqrt());
-                let b1 = -TWO * a * ((a - T::one()) + (a + T::one()) * omega_c);
-                let b2 = a * ((a + T::one()) + (a - T::one()) * omega_c - TWO * alpha * a.sqrt());
-                let a0 = (a + T::one()) - (a - T::one()) * omega_c + TWO * alpha * a.sqrt();
-                let a1 = TWO * ((a - T::one()) - (a + T::one()) * omega_c);
-                let a2 = (a + T::one()) - (a - T::one()) * omega_c - TWO * alpha * a.sqrt();
+                let b0 = a * ((a + C::one()) + (a - C::one()) * omega_c + TWO * alpha * a.sqrt());
+                let b1 = -TWO * a * ((a - C::one()) + (a + C::one()) * omega_c);
+                let b2 = a * ((a + C::one()) + (a - C::one()) * omega_c - TWO * alpha * a.sqrt());
+                let a0 = (a + C::one()) - (a - C::one()) * omega_c + TWO * alpha * a.sqrt();
+                let a1 = TWO * ((a - C::one()) - (a + C::one()) * omega_c);
+                let a2 = (a + C::one()) - (a - C::one()) * omega_c - TWO * alpha * a.sqrt();
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -269,16 +269,16 @@ impl<T: Float> Coefficients<T> {
                 })
             }
             Type::PeakingEQ(db_gain) => {
-                let a = T::from(T::from(10).unwrap().powf(db_gain / FORTY)).unwrap();
+                let a = C::from(C::from(10).unwrap().powf(db_gain / FORTY)).unwrap();
 
-                let b0 = T::one() + alpha * a;
+                let b0 = C::one() + alpha * a;
                 let b1 = -TWO * omega_c;
-                let b2 = T::one() - alpha * a;
-                let a0 = T::one() + alpha / a;
+                let b2 = C::one() - alpha * a;
+                let a0 = C::one() + alpha / a;
                 let a1 = -TWO * omega_c;
-                let a2 = T::one() - alpha / a;
+                let a2 = C::one() - alpha / a;
 
-                let div = T::one() / a0;
+                let div = C::one() / a0;
 
                 Ok(Coefficients {
                     a1: a1 * div,
@@ -294,33 +294,33 @@ impl<T: Float> Coefficients<T> {
     /// value. Note that the cutoff frequency must be smaller than half the sampling frequency and
     /// that Q may not be negative, this will result in an `Err()`.
     pub fn from_params(
-        filter: Type<T>,
-        fs: Hertz<T>,
-        f0: Hertz<T>,
-        q_value: T,
-    ) -> Result<Coefficients<T>, Errors> {
-        let normalized_f0 = f0.hz() / (fs.hz() / T::from(2).unwrap());
+        filter: Type<C>,
+        fs: Hertz<C>,
+        f0: Hertz<C>,
+        q_value: C,
+    ) -> Result<Coefficients<C>, Errors> {
+        let normalized_f0 = f0.hz() / (fs.hz() / C::from(2).unwrap());
         Self::from_normalized_params(filter, normalized_f0, q_value)
     }
 
     //
     pub fn band_0db_from_cutting_frequencies(
-        filter_type: Type<T>,
-        normalized_f01: T,
-        normalized_f02: T,
-    ) -> Result<Coefficients<T>, Errors> {
-        if normalized_f01 < T::zero()
-            || normalized_f02 < T::zero()
-            || normalized_f01 > T::one()
-            || normalized_f02 > T::one()
+        filter_type: Type<C>,
+        normalized_f01: C,
+        normalized_f02: C,
+    ) -> Result<Coefficients<C>, Errors> {
+        if normalized_f01 < C::zero()
+            || normalized_f02 < C::zero()
+            || normalized_f01 > C::one()
+            || normalized_f02 > C::one()
             || normalized_f01 > normalized_f02
         {
             return Err(Errors::OutsideNyquist);
         }
         #[allow(non_snake_case)]
-        let TWO: T = T::from(2).unwrap();
+        let TWO: C = C::from(2).unwrap();
         assert!(filter_type == Type::<_>::BandPass || filter_type == Type::<_>::Notch);
-        let frac_freq: T = normalized_f02 / normalized_f01;
+        let frac_freq: C = normalized_f02 / normalized_f01;
         let bw_in_octaves = frac_freq.log2();
         let normalized_f0 = TWO.powf(normalized_f01.log2() + bw_in_octaves / TWO);
         // #[allow(non_snake_case)]
@@ -329,6 +329,6 @@ impl<T: Float> Coefficients<T> {
         //
         // let q_value =
         //     T::one() / (TWO * (TWO.ln() * bw_in_octaves * (omega_0 / omega_0.sin()) / TWO).sinh());
-        Self::from_normalized_params(filter_type, normalized_f0, T::one())
+        Self::from_normalized_params(filter_type, normalized_f0, C::one())
     }
 }


### PR DESCRIPTION
I wanted to use this crate with complex numbers from [`num-complex`][1], so I separated the generic parameter into `C` and `T`.

`C` is for the coefficients, and for the methods on `Coefficients` to exist, it still needs to be `Float`. The strict bounds of `C` on the main types have been removed (e.g. trait bounds on the struct itself).

`T` is for the input, output and state of the filters. This can be anything that can be zero, added or subtracted with itself, or multiplied with `C`. So this applies to `C` or `Complex<C>` for example.

At first I wanted the generic parameters on the main types to be ordered `<T, C>`, but I opted to use `<C, T=C>`, so that the types can be instantiated with only specifying one (e.g. `DirectForm1<f32>`)

[1]: https://docs.rs/num-complex/latest/num_complex/index.html